### PR TITLE
feat: Implement novade-domain layer

### DIFF
--- a/novade-core/src/config/loader.rs
+++ b/novade-core/src/config/loader.rs
@@ -63,7 +63,7 @@ where
 {
     let content = fs::read_to_string(path).map_err(|err| CoreError::ConfigLoadError {
         path: path.to_path_buf(), // Klone den Pfad für die Fehlerstruktur.
-        source: err,
+        error_message: err.to_string(), // .source zu .error_message und err.to_string()
     })?;
 
     toml::from_str(&content).map_err(|err| CoreError::ConfigParseError {

--- a/novade-core/src/utils.rs
+++ b/novade-core/src/utils.rs
@@ -59,7 +59,7 @@
 
 use crate::error::{CoreError, CoreResult};
 use std::fs;
-use std::path::{Component, Path, PathBuf, MAIN_SEPARATOR}; // MAIN_SEPARATOR für Tests
+use std::path::{Component, Path, PathBuf}; // MAIN_SEPARATOR für Tests entfernt
 
 /// Löst einen möglicherweise relativen Pfad relativ zu einem gegebenen Basispfad auf und normalisiert ihn.
 ///
@@ -189,7 +189,7 @@ pub fn resolve_path(base_path: &Path, relative_path_str: &str) -> CoreResult<Pat
 /// }
 /// ```
 pub fn read_file_to_string(path: &Path) -> CoreResult<String> {
-    fs::read_to_string(path).map_err(CoreError::from)
+    fs::read_to_string(path).map_err(|err| CoreError::IoError(err.to_string()))
 }
 
 /// Ermittelt das Standard-Konfigurationsverzeichnis für die Anwendung gemäß den Konventionen des Betriebssystems.

--- a/novade-domain/Cargo.toml
+++ b/novade-domain/Cargo.toml
@@ -7,4 +7,11 @@ license.workspace = true
 
 [dependencies]
 novade-core = { path = "../novade-core" }
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+async-trait = "0.1"
 # Weitere domänenspezifische Abhängigkeiten später hinzufügen
+
+[dev-dependencies]
+mockall = "0.11"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/novade-domain/src/entities/application.rs
+++ b/novade-domain/src/entities/application.rs
@@ -1,0 +1,112 @@
+//! # Application Entität (`entities::application`)
+//!
+//! Definiert die Kernentität [`Application`] zur Repräsentation einer Anwendung
+//! im NovaDE-System sowie den zugehörigen Typ [`ApplicationType`].
+//!
+//! Eine `Application` kann eine Desktop-Anwendung, ein Kommandozeilen-Tool,
+//! ein Hintergrunddienst oder eine Web-Anwendung sein. Die Struktur hält
+//! Metadaten wie Name, Pfad zur ausführbaren Datei, Icon, Kategorien und Version.
+
+use novade_core::types::{NovaId, Version};
+use serde::{Deserialize, Serialize};
+
+/// Repräsentiert den Typ oder die Kategorie einer Anwendung.
+///
+/// Dies hilft dem System zu verstehen, wie eine Anwendung behandelt oder dargestellt werden soll.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ApplicationType {
+    /// Eine grafische Anwendung, typischerweise mit einer Desktop-Datei assoziiert.
+    Desktop,
+    /// Eine reine Kommandozeilenanwendung.
+    Cli,
+    /// Eine Web-Anwendung, die als eigenständige Entität im System repräsentiert wird.
+    WebService,
+    /// Ein Dienst, der im Hintergrund läuft und keine direkte Benutzeroberfläche hat.
+    BackgroundService,
+    /// Für andere, nicht spezifisch aufgeführte Anwendungstypen.
+    /// Das Feld enthält eine genauere Beschreibung des Typs.
+    Other(String),
+}
+
+/// Repräsentiert eine Anwendung, die im NovaDE-System bekannt ist und verwaltet werden kann.
+///
+/// Enthält alle notwendigen Informationen, um eine Anwendung zu identifizieren, darzustellen
+/// und potenziell zu starten.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Application {
+    /// Ein eindeutiger Identifikator für die Anwendung, generiert als [`NovaId`].
+    pub id: NovaId,
+    /// Der primäre, oft technische Name der Anwendung (z.B. "firefox", "org.gnome.TextEditor").
+    pub name: String,
+    /// Ein optionaler, benutzerfreundlicherer Anzeigename für die UI (z.B. "Firefox Web Browser").
+    /// Wenn nicht gesetzt, kann `name` verwendet werden.
+    pub display_name: Option<String>,
+    /// Der vollständige Pfad zur ausführbaren Datei der Anwendung oder der auszuführende Befehl.
+    pub executable_path: String,
+    /// Optionale Liste von Standardargumenten, die beim Start der Anwendung übergeben werden sollen.
+    pub arguments: Option<Vec<String>>,
+    /// Optionales Arbeitsverzeichnis, in dem die Anwendung gestartet werden soll.
+    pub working_directory: Option<String>,
+    /// Name des Icons für die Anwendung, typischerweise gemäß der Freedesktop Icon Theme Specification
+    /// (z.B. "firefox", "system-search"). Das System ist verantwortlich, das passende Icon-Theme zu finden.
+    pub icon_name: Option<String>,
+    /// Der Typ der Anwendung, definiert durch [`ApplicationType`].
+    pub app_type: ApplicationType,
+    /// Optionale Liste von Kategorien, denen die Anwendung zugeordnet ist (z.B. "Network", "Office", "Utility").
+    /// Orientiert sich oft an den Kategorien der Freedesktop .desktop-Spezifikation.
+    pub categories: Option<Vec<String>>,
+    /// Optionale Liste von Schlüsselwörtern, die für die Suche nach der Anwendung verwendet werden können.
+    pub keywords: Option<Vec<String>>,
+    /// Eine kurze, optionale Beschreibung der Funktionalität der Anwendung.
+    pub description: Option<String>,
+    /// Die Version der Anwendung, falls bekannt, repräsentiert durch [`novade_core::types::Version`].
+    pub version: Option<Version>,
+}
+
+impl Application {
+    /// Erstellt eine neue `Application` vom Typ [`ApplicationType::Desktop`].
+    ///
+    /// Dies ist ein Hilfskonstruktor für einen häufigen Anwendungsfall.
+    /// Die ID wird automatisch generiert. Viele Felder bleiben `None` und können später gesetzt werden.
+    ///
+    /// # Parameter
+    /// * `name`: Der technische Name der Anwendung.
+    /// * `executable_path`: Der Pfad zur ausführbaren Datei.
+    /// * `icon_name`: Optional der Name des Icons.
+    ///
+    /// # Beispiele
+    /// ```
+    /// use novade_domain::entities::Application;
+    ///
+    /// let my_app = Application::new_desktop(
+    ///     "my-editor".to_string(),
+    ///     "/usr/bin/my-editor".to_string(),
+    ///     Some("accessories-text-editor".to_string())
+    /// );
+    /// assert_eq!(my_app.name, "my-editor");
+    /// assert_eq!(my_app.app_type, novade_domain::entities::ApplicationType::Desktop);
+    /// ```
+    pub fn new_desktop(
+        name: String,
+        executable_path: String,
+        icon_name: Option<String>,
+    ) -> Self {
+        Self {
+            id: NovaId::new(),
+            name,
+            display_name: None,
+            executable_path,
+            arguments: None,
+            working_directory: None,
+            icon_name,
+            app_type: ApplicationType::Desktop,
+            categories: None,
+            keywords: None,
+            description: None,
+            version: None,
+        }
+    }
+
+    // Weitere spezifische Konstruktoren oder Builder-Methoden könnten hier folgen,
+    // z.B. `Application::new_cli(...)` oder ein `ApplicationBuilder`.
+}

--- a/novade-domain/src/entities/mod.rs
+++ b/novade-domain/src/entities/mod.rs
@@ -1,0 +1,26 @@
+//! # Domänenentitäten (`entities`)
+//!
+//! Dieses Modul enthält die Definitionen der Kern-Domänenentitäten von NovaDE.
+//! Diese Entitäten repräsentieren die zentralen Konzepte und Datenstrukturen,
+//! mit denen die Domänenlogik in den [`crate::services`] operiert.
+//!
+//! Jede Entität ist in ihrem eigenen Untermodul definiert:
+//! - [`application`]: Definiert [`Application`] und [`ApplicationType`].
+//! - [`user_preference`]: Definiert [`UserPreferenceSetting`] und [`PreferenceValue`].
+//! - [`workspace`]: Definiert [`Workspace`].
+//!
+//! Die wichtigsten Entitäten werden hier für einen einfacheren Zugriff aus anderen Teilen
+//! der `novade-domain` Crate oder von externen Crates re-exportiert.
+
+pub mod application;
+pub mod user_preference;
+pub mod workspace;
+
+// Re-exportiere die Kernentitäten für einen einfacheren Zugriff.
+// Dies ermöglicht es, z.B. `novade_domain::entities::Application` anstelle von
+// `novade_domain::entities::application::Application` zu verwenden, wenn dieses Modul importiert wird.
+// Für den direkten Zugriff über `novade_domain::*` (wie in `lib.rs` konfiguriert) sind diese spezifischen
+// Re-Exporte hier weniger kritisch, aber sie sind nützlich für eine klare Struktur innerhalb des `entities`-Moduls.
+pub use application::{Application, ApplicationType};
+pub use user_preference::{PreferenceValue, UserPreferenceSetting};
+pub use workspace::Workspace;

--- a/novade-domain/src/entities/user_preference.rs
+++ b/novade-domain/src/entities/user_preference.rs
@@ -1,0 +1,105 @@
+//! # User Preference Entitäten (`entities::user_preference`)
+//!
+//! Definiert Entitäten zur Darstellung von Benutzereinstellungen im NovaDE-System,
+//! insbesondere [`UserPreferenceSetting`] und den dazugehörigen Wert-Typ [`PreferenceValue`].
+//!
+//! Diese Strukturen ermöglichen es, verschiedene Arten von Einstellungen flexibel zu speichern
+//! und zu verwalten, inklusive Metadaten wie Anzeigename, Beschreibung und ob ein Neustart
+//! für die Aktivierung der Einstellung erforderlich ist.
+
+// use novade_core::types::NovaId; // Import von NovaId für zukünftige Benutzerbindung - aktuell nicht verwendet
+use serde::{Deserialize, Serialize};
+
+/// Repräsentiert den tatsächlichen Wert einer Benutzereinstellung.
+///
+/// Dieses Enum ermöglicht es, verschiedene Datentypen für Einstellungen zu speichern.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PreferenceValue {
+    /// Ein Textwert.
+    String(String),
+    /// Ein ganzzahliger Wert.
+    Integer(i64),
+    /// Ein Fließkommawert.
+    Float(f64),
+    /// Ein boolescher Wert (wahr/falsch).
+    Boolean(bool),
+    /// Ein Farbwert, typischerweise als RGBA-String (z.B. "#RRGGBBAA" oder "rgba(r,g,b,a)").
+    ColorRgba(String),
+    /// Eine Liste von Textwerten.
+    StringList(Vec<String>),
+    // Zukünftige Erweiterungen könnten spezifischere Typen wie Keybinding, FontSetting etc. umfassen.
+    // Enum(String, Vec<String>), // z.B. Enum("OptionA", vec!["OptionA", "OptionB"])
+}
+
+/// Repräsentiert eine einzelne, konfigurierbare Benutzereinstellung im System.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserPreferenceSetting {
+    /// Ein eindeutiger, maschinenlesbarer Schlüssel für die Einstellung.
+    ///
+    /// Konvention: `bereich.unterbereich.einstellung` (z.B. "theme.dark_mode_enabled", "keyboard.layout").
+    pub key: String,
+    /// Der aktuelle Wert der Einstellung, gespeichert als [`PreferenceValue`].
+    pub value: PreferenceValue,
+    /// Ein benutzerfreundlicher Name für die Einstellung, der in UIs angezeigt werden kann.
+    pub display_name: String,
+    /// Eine optionale, ausführlichere Beschreibung der Funktion dieser Einstellung.
+    pub description: Option<String>,
+    /// Gibt an, ob eine Änderung dieser Einstellung einen Neustart der Anwendung
+    /// oder des gesamten Systems erfordert, um wirksam zu werden.
+    pub requires_restart: bool,
+    /// Eine optionale Gruppierungskategorie für die Einstellung,
+    /// nützlich zur Organisation in Einstellungsdialogen (z.B. "Erscheinungsbild", "System", "Fensterverhalten").
+    pub group: Option<String>,
+    // Zukünftig könnte hier eine `user_id: Option<NovaId>` stehen, um Einstellungen
+    // benutzerspezifisch zu machen oder systemweite Standardwerte zu kennzeichnen.
+    // Für den Moment wird angenommen, dass Einstellungen global oder durch den Kontext
+    // des Repositories benutzergebunden sind.
+}
+
+impl UserPreferenceSetting {
+    /// Erstellt eine neue boolesche Benutzereinstellung.
+    ///
+    /// # Parameter
+    /// * `key`: Der eindeutige Schlüssel für die Einstellung.
+    /// * `display_name`: Der in der UI anzuzeigende Name.
+    /// * `default_value`: Der initiale boolesche Wert der Einstellung.
+    ///
+    /// # Beispiele
+    /// ```
+    /// use novade_domain::entities::UserPreferenceSetting;
+    ///
+    /// let dark_mode_setting = UserPreferenceSetting::new_boolean(
+    ///     "theme.dark_mode",
+    ///     "Dunkler Modus",
+    ///     false
+    /// );
+    /// assert_eq!(dark_mode_setting.key, "theme.dark_mode");
+    /// match dark_mode_setting.value {
+    ///     novade_domain::entities::PreferenceValue::Boolean(val) => assert!(!val),
+    ///     _ => panic!("Falscher Werttyp"),
+    /// }
+    /// ```
+    pub fn new_boolean(key: &str, display_name: &str, default_value: bool) -> Self {
+        Self {
+            key: key.to_string(),
+            value: PreferenceValue::Boolean(default_value),
+            display_name: display_name.to_string(),
+            description: None,
+            requires_restart: false,
+            group: None,
+        }
+    }
+
+    /// Erstellt eine neue String-Benutzereinstellung.
+    pub fn new_string(key: &str, display_name: &str, default_value: String) -> Self {
+        Self {
+            key: key.to_string(),
+            value: PreferenceValue::String(default_value),
+            display_name: display_name.to_string(),
+            description: None,
+            requires_restart: false,
+            group: None,
+        }
+    }
+    // Weitere Konstruktoren für andere Typen (Integer, Float, etc.) können bei Bedarf hinzugefügt werden.
+}

--- a/novade-domain/src/entities/workspace.rs
+++ b/novade-domain/src/entities/workspace.rs
@@ -1,0 +1,73 @@
+//! # Workspace Entität (`entities::workspace`)
+//!
+//! Definiert die Kernentität [`Workspace`] zur Repräsentation eines Arbeitsbereichs
+//! oder virtuellen Desktops innerhalb von NovaDE.
+//!
+//! Ein `Workspace` ist eine logische Gruppierung von Anwendungsfenstern und deren
+//! Anordnung, typischerweise assoziiert mit einem oder mehreren Bildschirmen.
+//! Er ermöglicht es Benutzern, ihre Arbeitsumgebung für verschiedene Aufgaben
+//! oder Kontexte zu organisieren.
+
+use novade_core::types::NovaId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Repräsentiert einen Arbeitsbereich (Workspace) in NovaDE.
+///
+/// Ein Workspace kann als ein virtueller Desktop betrachtet werden, der eine bestimmte
+/// Menge von Fenstern, deren Layout und zugehörige Einstellungen enthält.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Workspace {
+    /// Ein eindeutiger Identifikator für den Workspace, generiert als [`NovaId`].
+    pub id: NovaId,
+    /// Ein benutzerdefinierter Name für den Workspace (z.B. "Arbeit", "Freizeit", "Entwicklung").
+    pub name: String,
+    /// Eine Beschreibung oder Konfiguration des Layouts für diesen Workspace.
+    ///
+    /// Dies könnte ein JSON-String sein, der Fensterpositionen und -größen beschreibt,
+    /// oder ein Verweis auf ein vordefiniertes Layout-Template (z.B. "Kacheln", "Überlappend").
+    /// Die genaue Interpretation liegt bei der UI- oder Systemschicht.
+    pub layout_configuration: String,
+    /// Optionale ID des primären Outputs (Bildschirms), mit dem dieser Workspace
+    /// hauptsächlich verbunden ist. Nützlich in Multi-Monitor-Setups.
+    pub primary_output_id: Option<String>, // Z.B. Name oder ID des Monitors
+    /// Zusätzliche Metadaten oder benutzerspezifische Einstellungen für den Workspace.
+    ///
+    /// Kann verwendet werden, um beliebige Schlüssel-Wert-Paare zu speichern,
+    /// wie z.B. Hintergrundbild, spezifische Panel-Einstellungen etc.
+    pub metadata: HashMap<String, String>,
+}
+
+impl Workspace {
+    /// Erstellt einen neuen `Workspace` mit einem gegebenen Namen und optionaler ID des primären Outputs.
+    ///
+    /// Die ID des Workspaces wird automatisch generiert. Die `layout_configuration` wird
+    /// standardmäßig auf "default" gesetzt.
+    ///
+    /// # Parameter
+    /// * `name`: Der Name für den neuen Workspace.
+    /// * `primary_output_id`: Optionale ID des Bildschirms, dem dieser Workspace zugeordnet werden soll.
+    ///
+    /// # Beispiele
+    /// ```
+    /// use novade_domain::entities::Workspace;
+    ///
+    /// let ws1 = Workspace::new("Coding Space".to_string(), Some("HDMI-1".to_string()));
+    /// assert_eq!(ws1.name, "Coding Space");
+    /// assert_eq!(ws1.primary_output_id.as_deref(), Some("HDMI-1"));
+    /// assert_eq!(ws1.layout_configuration, "default");
+    ///
+    /// let ws2 = Workspace::new("General".to_string(), None);
+    /// assert_eq!(ws2.name, "General");
+    /// assert!(ws2.primary_output_id.is_none());
+    /// ```
+    pub fn new(name: String, primary_output_id: Option<String>) -> Self {
+        Self {
+            id: NovaId::new(),
+            name,
+            layout_configuration: "default".to_string(), // Ein einfacher Standardwert
+            primary_output_id,
+            metadata: HashMap::new(),
+        }
+    }
+}

--- a/novade-domain/src/error.rs
+++ b/novade-domain/src/error.rs
@@ -1,0 +1,97 @@
+//! # Fehlerbehandlung in `novade-domain`
+//!
+//! Dieses Modul definiert die zentralen Fehler-Typen spezifisch für die `novade-domain` Schicht.
+//! Das Haupt-Enum ist [`DomainError`], und [`DomainResult<T>`] ist ein praktischer Typalias
+//! für `Result<T, DomainError>`.
+//!
+//! Domänenspezifische Fehler können auftreten, wenn Geschäftsregeln verletzt werden,
+//! Entitäten nicht gefunden werden oder Operationen nicht zulässig sind.
+//! Zusätzlich können Fehler aus der `novade-core` Schicht, insbesondere bei Repository-Operationen,
+//! in `DomainError` gewrappt werden (siehe [`DomainError::RepositoryError`]).
+//!
+//! ## Verwendung
+//!
+//! Funktionen und Methoden innerhalb von `novade-domain` (insbesondere in den Diensten)
+//! sollten `DomainResult<T>` als Rückgabetyp verwenden, um domänenspezifische Fehler
+//! klar zu signalisieren.
+//!
+//! ```rust,no_run
+//! use novade_domain::error::{DomainResult, DomainError};
+//! use novade_domain::entities::Application; // Beispiel-Entität
+//!
+//! // Beispiel für eine Funktion, die einen DomainError zurückgeben könnte
+//! fn validate_application_name(app: &Application) -> DomainResult<()> {
+//!     if app.name.is_empty() {
+//!         Err(DomainError::ValidationError {
+//!             field: "application.name".to_string(),
+//!             message: "Anwendungsname darf nicht leer sein.".to_string(),
+//!         })
+//!     } else {
+//!         Ok(())
+//!     }
+//! }
+//! ```
+
+use novade_core::CoreError; // Importiere CoreError für das Wrapping
+use thiserror::Error;
+
+/// Ein Alias für `Result<T, DomainError>`, der die Fehlerbehandlung in `novade-domain` vereinfacht.
+///
+/// Anstelle von `Result<MyType, novade_domain::error::DomainError>` kann einfach `DomainResult<MyType>`
+/// geschrieben werden, vorausgesetzt, `DomainError` ist im aktuellen Gültigkeitsbereich.
+pub type DomainResult<T> = Result<T, DomainError>;
+
+/// Haupt-Enum für alle Fehler, die innerhalb der `novade-domain` Schicht auftreten können.
+///
+/// Jede Variante repräsentiert eine spezifische domänenbezogene Fehlerbedingung.
+/// Die `#[error(...)]` Attribute von `thiserror` werden verwendet, um aussagekräftige
+/// Fehlermeldungen zu generieren.
+#[derive(Debug, Error)]
+pub enum DomainError {
+    /// Wird zurückgegeben, wenn eine erwartete Entität nicht gefunden wurde.
+    #[error("Entität '{entity_type}' mit ID '{entity_id}' nicht gefunden.")]
+    EntityNotFound {
+        /// Der Typ der Entität (z.B. "Application", "Workspace").
+        entity_type: String,
+        /// Die ID der nicht gefundenen Entität.
+        entity_id: String, // Könnte auch NovaId sein, aber String ist flexibler für die Fehlermeldung.
+    },
+
+    /// Wird zurückgegeben, wenn eine Validierungsregel für ein Feld einer Entität verletzt wurde.
+    #[error("Validierungsfehler für Feld '{field}': {message}")]
+    ValidationError {
+        /// Der Name des Feldes, das die Validierung nicht bestanden hat (z.B. "application.name").
+        field: String,
+        /// Eine Beschreibung des Validierungsfehlers.
+        message: String,
+    },
+
+    /// Wird zurückgegeben, wenn eine angeforderte Operation unter den aktuellen Umständen nicht erlaubt ist.
+    #[error("Operation '{operation}' nicht erlaubt: {reason}")]
+    OperationNotPermitted {
+        /// Die Bezeichnung der nicht erlaubten Operation (z.B. "delete_default_workspace").
+        operation: String,
+        /// Der Grund, warum die Operation nicht erlaubt ist.
+        reason: String,
+    },
+
+    /// Kapselt einen Fehler, der aus der darunterliegenden `novade-core` Schicht stammt,
+    /// oft im Kontext von Repository-Operationen (z.B. E/A-Fehler beim Dateizugriff).
+    ///
+    /// Diese Variante kann durch `#[from]` automatisch aus `novade_core::CoreError` konvertiert werden.
+    #[error("Fehler in der Repository-Schicht oder Kernfunktionalität: {0}")]
+    RepositoryError(#[from] CoreError),
+
+    /// Ein spezifischer Fehler innerhalb eines Domänendienstes.
+    #[error("Fehler im Domänendienst '{service_name}': {message}")]
+    ServiceError {
+        /// Der Name des Dienstes, in dem der Fehler aufgetreten ist.
+        service_name: String,
+        /// Eine Beschreibung des Dienstfehlers.
+        message: String,
+    },
+    
+    /// Ein unspezifischer oder nicht anderweitig kategorisierter Fehler innerhalb von `novade-domain`.
+    #[error("Ein unbekannter Domänenfehler ist aufgetreten: {0}")]
+    UnknownError(String),
+}

--- a/novade-domain/src/lib.rs
+++ b/novade-domain/src/lib.rs
@@ -1,12 +1,134 @@
-//! novade-domain: Zentrale Geschäftslogik und domänenspezifische Entitäten.
+//! # NovaDE Domänenschicht (`novade-domain`)
+//!
+//! `novade-domain` definiert die Kernlogik und die domänenspezifischen Entitäten
+//! des NovaDE Linux Desktop Environments. Diese Schicht ist verantwortlich für
+//! die Geschäftsregeln und agiert unabhängig von UI- und Systemdetails.
+//! Sie baut auf `novade-core` auf.
+//!
+//! ## Hauptkomponenten:
+//!
+//! - **Entitäten ([`entities`])**: Datenstrukturen, die Kernkonzepte wie Anwendungen
+//!   ([`Application`]), Arbeitsbereiche ([`Workspace`]) und Benutzereinstellungen
+//!   ([`UserPreferenceSetting`]) repräsentieren.
+//! - **Repositories ([`repositories`])**: Traits, die Abstraktionen für den Datenzugriff
+//!   auf Entitäten definieren (z.B. [`ApplicationRepository`]). Diese werden von
+//!   der Systemschicht implementiert.
+//! - **Dienste ([`services`])**: Implementieren die eigentliche Geschäftslogik und
+//!   orchestrieren Operationen unter Verwendung von Entitäten und Repository-Abstraktionen
+//!   (z.B. [`ApplicationService`], [`WorkspaceService`]).
+//! - **Fehlerbehandlung ([`error`])**: Definiert domänenspezifische Fehler (`DomainError`)
+//!   und ein `DomainResult<T>` für Operationen innerhalb dieser Schicht.
+//!
+//! ## Designprinzipien:
+//!
+//! - **Unabhängigkeit**: Keine Abhängigkeiten zu `novade-system` oder `novade-ui`.
+//! - **Testbarkeit**: Geschäftslogik ist isoliert und kann durch Mocking der Repositories
+//!   gut getestet werden.
+//! - **Klare Schnittstellen**: Definiert klare Verträge für die Interaktion mit der Systemschicht
+//!   (über Repository-Implementierungen) und der UI-Schicht (über die Domänendienste).
+//!
+//! ## Verwendung:
+//!
+//! Die System- und UI-Schichten verwenden `novade-domain`, um auf Geschäftslogik und -daten zuzugreifen.
+//!
+//! ```rust,no_run
+//! use novade_domain::services::ApplicationService;
+//! use novade_domain::repositories::ApplicationRepository; // Trait
+//! use novade_domain::entities::Application;
+//! use novade_domain::DomainResult;
+//! use novade_core::types::NovaId;
+//! use async_trait::async_trait;
+//! use std::sync::Arc;
+//!
+//! // Beispiel für eine Mock-Implementierung eines Repositories (typischerweise in der Systemschicht oder in Tests)
+//! struct MockAppRepo;
+//!
+//! #[async_trait]
+//! impl ApplicationRepository for MockAppRepo {
+//!     async fn get_by_id(&self, id: &NovaId) -> DomainResult<Option<Application>> {
+//!         // ... Mock-Implementierung ...
+//!         Ok(None)
+//!     }
+//!     async fn get_all(&self) -> DomainResult<Vec<Application>> { Ok(vec![]) }
+//!     async fn find_by_name(&self, search_term: &str) -> DomainResult<Vec<Application>> { Ok(vec![]) }
+//!     async fn add(&self, application: &Application) -> DomainResult<()> { Ok(()) }
+//!     async fn update(&self, application: &Application) -> DomainResult<()> { Ok(()) }
+//!     async fn remove(&self, id: &NovaId) -> DomainResult<()> { Ok(()) }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> DomainResult<()> {
+//!     // Logging initialisieren (aus novade-core)
+//!     let core_config = novade_core::CoreConfig::example();
+//!     let _ = novade_core::initialize_logging(&core_config);
+//!
+//!     let app_repo = Arc::new(MockAppRepo);
+//!     let app_service = ApplicationService::new(app_repo);
+//!
+//!     let apps = app_service.list_all_applications().await?;
+//!     novade_core::info!("Gefundene Anwendungen: {}", apps.len());
+//!
+//!     Ok(())
+//! }
+//! ```
 
-// Beispiel für ein Domänenmodul
-// pub mod entities;
-// pub mod services;
-// pub mod repositories;
+// Module werden öffentlich gemacht
+pub mod entities;
+pub mod error;
+pub mod repositories;
+pub mod services;
+
+// Re-exportiere die wichtigsten Elemente für eine einfachere Nutzung.
+pub use error::{DomainError, DomainResult};
+
+// Re-Exporte aus entities (Beispiele, je nach Häufigkeit der Nutzung anpassen)
+pub use entities::{
+    Application, ApplicationType, PreferenceValue, UserPreferenceSetting, Workspace,
+};
+
+// Re-Exporte aus repositories (Traits sind wichtig für Implementierer)
+pub use repositories::{
+    ApplicationRepository, UserPreferenceRepository, WorkspaceRepository,
+};
+
+// Re-Exporte aus services (Dienste sind die Haupt-Einstiegspunkte für die Logik)
+pub use services::{ApplicationService, WorkspaceService};
+
 
 /// Gibt eine Testnachricht aus, um die Funktionalität der Domänenschicht zu demonstrieren.
+///
+/// Diese Funktion dient primär zu Test- und Demonstrationszwecken.
 pub fn print_domain_message() {
-    novade_core::print_core_message(); // Beispiel für Aufruf aus novade-core
-    println!("Nachricht von novade-domain: Domänenlogik bereit.");
+    // Rufe eine Funktion aus novade-core auf, um die Abhängigkeit zu zeigen
+    novade_core::print_core_message();
+
+    // Verwende das Logging aus novade-core
+    novade_core::info!(target: "novade_domain_lib", "Nachricht von novade-domain: Domänenlogik bereit.");
+    println!("Nachricht von novade-domain: Domänenlogik bereit (via println).");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Importiert alles aus dem lib-Modul, inkl. re-exportierter Typen
+
+    #[test]
+    fn test_print_domain_message_from_lib() {
+        // Logging für den Test initialisieren
+        let core_config = novade_core::CoreConfig::example();
+        let _ = novade_core::initialize_logging(&core_config);
+
+        print_domain_message();
+    }
+
+    #[test]
+    fn test_domain_imports_are_accessible() {
+        // Dieser Test prüft, ob die Re-Exporte funktionieren und Typen zugänglich sind.
+        // Er ist mehr ein Compile-Zeit-Check.
+        let _app_service: Option<ApplicationService> = None; // Nur Typverwendung
+        let _id = novade_core::types::NovaId::new(); // Sicherstellen, dass Core-Typen auch gehen
+        let _app = Application::new_desktop("test".to_string(), "/bin/test".to_string(), None);
+        
+        novade_core::info!("Domain-Import-Test: Typen sind zugänglich.");
+        // Keine Assertions nötig, der Test besteht, wenn er kompiliert.
+    }
 }

--- a/novade-domain/src/repositories/application_repository.rs
+++ b/novade-domain/src/repositories/application_repository.rs
@@ -1,0 +1,95 @@
+//! # Application Repository Trait (`repositories::application_repository`)
+//!
+//! Definiert das Trait [`ApplicationRepository`], das als Abstraktion für den
+//! Datenzugriff auf [`Application`](crate::entities::Application) Entitäten dient.
+//!
+//! Dieses Trait muss von einer konkreten Implementierung in der Systemschicht
+//! (`novade-system`) erfüllt werden, um die tatsächliche Speicherung und das Abrufen
+//! von Anwendungsdaten zu handhaben (z.B. aus einer Datenbank, Konfigurationsdateien
+//! oder einem Verzeichnis von `.desktop`-Dateien).
+
+use crate::entities::application::Application;
+use crate::DomainResult; // Stellt sicher, dass Fehler als DomainError zurückgegeben werden
+use async_trait::async_trait;
+use novade_core::types::NovaId;
+
+/// Ein Trait, das Operationen zum Speichern, Abrufen und Verwalten von
+/// [`Application`](crate::entities::Application)-Entitäten abstrahiert.
+///
+/// Implementierungen dieses Traits sind verantwortlich für die Persistenzlogik.
+/// Das Trait ist als `async_trait` definiert, um asynchrone Operationen zu ermöglichen,
+#[cfg_attr(test, mockall::automock)] // Hinzugefügt für Mocking in Tests
+/// was typisch für I/O-gebundene Aufgaben wie Datenbankzugriffe ist.
+/// Die `Send + Sync` Bounds sind notwendig, damit Implementierungen sicher über Threads
+/// hinweg geteilt werden können (z.B. wenn sie in einem `Arc` gehalten werden).
+#[async_trait]
+pub trait ApplicationRepository: Send + Sync {
+    /// Ruft eine spezifische Anwendung anhand ihrer eindeutigen ID ab.
+    ///
+    /// # Parameter
+    /// * `id`: Die [`NovaId`] der gesuchten Anwendung.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult` das bei Erfolg `Some(Application)` enthält, wenn die Anwendung
+    /// gefunden wurde, oder `None`, wenn keine Anwendung mit dieser ID existiert.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn get_by_id(&self, id: &NovaId) -> DomainResult<Option<Application>>;
+
+    /// Ruft eine Liste aller im System bekannten Anwendungen ab.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult` das bei Erfolg einen Vektor von `Application`-Entitäten enthält.
+    /// Der Vektor kann leer sein, wenn keine Anwendungen vorhanden sind.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn get_all(&self) -> DomainResult<Vec<Application>>;
+    
+    /// Sucht und ruft Anwendungen ab, deren Name (oder ggf. Anzeigename)
+    /// einem gegebenen Suchbegriff entspricht.
+    ///
+    /// Die genaue Suchlogik (z.B. exakte Übereinstimmung, Teilübereinstimmung, Groß-/Kleinschreibung)
+    /// ist der Implementierung überlassen.
+    ///
+    /// # Parameter
+    /// * `search_term`: Der Begriff, nach dem im Anwendungsnamen gesucht werden soll.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult` das bei Erfolg einen Vektor von passenden `Application`-Entitäten enthält.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn find_by_name(&self, search_term: &str) -> DomainResult<Vec<Application>>;
+
+    /// Fügt eine neue Anwendung zum Repository hinzu.
+    ///
+    /// # Parameter
+    /// * `application`: Eine Referenz auf die hinzuzufügende `Application`-Entität.
+    ///                  Es wird erwartet, dass die `id` der Anwendung bereits gesetzt ist.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn eine Anwendung
+    /// mit derselben ID bereits existiert oder ein Speicherfehler auftritt).
+    async fn add(&self, application: &Application) -> DomainResult<()>;
+
+    /// Aktualisiert eine bereits im Repository vorhandene Anwendung.
+    ///
+    /// Die zu aktualisierende Anwendung wird typischerweise anhand ihrer `id` identifiziert.
+    ///
+    /// # Parameter
+    /// * `application`: Eine Referenz auf die `Application`-Entität mit den aktualisierten Daten.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn die zu aktualisierende
+    /// Anwendung nicht gefunden wird).
+    async fn update(&self, application: &Application) -> DomainResult<()>;
+
+    /// Entfernt eine Anwendung anhand ihrer eindeutigen ID aus dem Repository.
+    ///
+    /// # Parameter
+    /// * `id`: Die [`NovaId`] der zu entfernenden Anwendung.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn keine Anwendung
+    /// mit dieser ID zum Entfernen gefunden wird).
+    async fn remove(&self, id: &NovaId) -> DomainResult<()>;
+}

--- a/novade-domain/src/repositories/mod.rs
+++ b/novade-domain/src/repositories/mod.rs
@@ -1,0 +1,29 @@
+//! # Repository-Abstraktionen (`repositories`)
+//!
+//! Dieses Modul definiert Traits, die als Abstraktionsebene für den Datenzugriff
+//! auf Domänenentitäten dienen. Diese Traits werden von der Systemschicht (`novade-system`)
+//! implementiert, beispielsweise mittels Datenbanken, Konfigurationsdateien oder anderen
+//! Persistenzmechanismen. Die Domänendienste ([`crate::services`]) verwenden diese Traits,
+//! um auf Entitätsdaten zuzugreifen und diese zu manipulieren, ohne die Details der
+//! konkreten Datenspeicherung kennen zu müssen.
+//!
+//! Dieses Design fördert die Entkopplung zwischen der Domänenlogik und der
+//! Infrastruktur für die Datenhaltung, was die Testbarkeit und Wartbarkeit verbessert.
+//!
+//! ## Definierte Repository-Traits:
+//!
+//! - [`application_repository::ApplicationRepository`]: Für den Zugriff auf [`Application`](crate::entities::Application) Entitäten.
+//! - [`user_preference_repository::UserPreferenceRepository`]: Für den Zugriff auf [`UserPreferenceSetting`](crate::entities::UserPreferenceSetting) Entitäten.
+//! - [`workspace_repository::WorkspaceRepository`]: Für den Zugriff auf [`Workspace`](crate::entities::Workspace) Entitäten.
+//!
+//! Die Traits werden hier für einen einfacheren Zugriff re-exportiert.
+
+pub mod application_repository;
+pub mod user_preference_repository;
+pub mod workspace_repository;
+
+// Re-exportiere die Repository-Traits, um den Zugriff für Implementierer und Nutzer zu vereinfachen.
+// Ermöglicht z.B. `use novade_domain::repositories::ApplicationRepository;`
+pub use application_repository::ApplicationRepository;
+pub use user_preference_repository::UserPreferenceRepository;
+pub use workspace_repository::WorkspaceRepository;

--- a/novade-domain/src/repositories/user_preference_repository.rs
+++ b/novade-domain/src/repositories/user_preference_repository.rs
@@ -1,0 +1,71 @@
+//! # User Preference Repository Trait (`repositories::user_preference_repository`)
+//!
+//! Definiert das Trait [`UserPreferenceRepository`], das als Abstraktion für den
+//! Datenzugriff auf [`UserPreferenceSetting`](crate::entities::user_preference::UserPreferenceSetting) Entitäten dient.
+//!
+//! Diese Schnittstelle ermöglicht das Speichern und Abrufen von Benutzereinstellungen,
+//! ohne dass die Domänendienste die Details der Persistenz kennen müssen.
+//! Die konkrete Implementierung erfolgt in der Systemschicht (`novade-system`).
+//!
+//! **Hinweis zur Benutzerbindung**: Die aktuellen Methoden sind nicht explizit
+//! benutzergebunden (d.h. sie nehmen keine `user_id` als Parameter). Es wird angenommen,
+//! dass die Implementierung des Repositories den aktuellen Benutzerkontext kennt
+//! oder dass die Einstellungen systemweit gelten. Zukünftige Erweiterungen könnten
+//! eine explizite Benutzer-ID einführen.
+
+use crate::entities::user_preference::UserPreferenceSetting;
+use crate::DomainResult;
+use async_trait::async_trait;
+// use novade_core::types::NovaId; // Auskommentiert, da aktuell nicht für Benutzerbindung verwendet
+
+/// Ein Trait, das Operationen zum Speichern und Abrufen von
+/// [`UserPreferenceSetting`](crate::entities::user_preference::UserPreferenceSetting)-Entitäten abstrahiert.
+///
+/// Implementierungen dieses Traits sind für die Persistenzlogik von Benutzereinstellungen zuständig.
+/// Das Trait ist `async_trait`, um asynchrone Operationen zu unterstützen.
+/// `Send + Sync` Bounds sind für die thread-sichere Nutzung erforderlich.
+#[async_trait]
+pub trait UserPreferenceRepository: Send + Sync {
+    /// Ruft eine spezifische Benutzereinstellung anhand ihres eindeutigen Schlüssels ab.
+    ///
+    /// # Parameter
+    /// * `key`: Der eindeutige Schlüssel der gesuchten Einstellung (z.B. "theme.dark_mode").
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult`, das bei Erfolg `Some(UserPreferenceSetting)` enthält, wenn die
+    /// Einstellung gefunden wurde, oder `None`, andernfalls ein `DomainError`.
+    async fn get_preference(&self, key: &str) -> DomainResult<Option<UserPreferenceSetting>>;
+    
+    /// Ruft eine Liste aller bekannten Benutzereinstellungen ab.
+    ///
+    /// Abhängig von der Implementierung können dies systemweite Standardeinstellungen
+    /// oder benutzerspezifische Einstellungen sein, falls der Kontext bekannt ist.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult`, das bei Erfolg einen Vektor von `UserPreferenceSetting`-Entitäten enthält.
+    /// Der Vektor kann leer sein. Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn get_all_preferences(&self) -> DomainResult<Vec<UserPreferenceSetting>>;
+
+    /// Speichert eine Benutzereinstellung (fügt hinzu oder aktualisiert sie).
+    ///
+    /// Wenn bereits eine Einstellung mit demselben Schlüssel existiert, wird diese
+    /// typischerweise überschrieben.
+    ///
+    /// # Parameter
+    /// * `setting`: Eine Referenz auf die zu speichernde `UserPreferenceSetting`.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn set_preference(&self, setting: &UserPreferenceSetting) -> DomainResult<()>;
+
+    // Zukünftige mögliche Erweiterungen:
+    // /// Entfernt eine Einstellung anhand ihres Schlüssels.
+    // async fn remove_preference(&self, key: &str) -> DomainResult<()>;
+    //
+    // /// Setzt eine Einstellung auf ihren Standardwert zurück (falls definiert).
+    // async fn reset_preference(&self, key: &str) -> DomainResult<()>;
+    //
+    // /// Setzt alle Einstellungen einer bestimmten Gruppe zurück.
+    // async fn reset_preferences_in_group(&self, group_name: &str) -> DomainResult<()>;
+}

--- a/novade-domain/src/repositories/workspace_repository.rs
+++ b/novade-domain/src/repositories/workspace_repository.rs
@@ -1,0 +1,89 @@
+//! # Workspace Repository Trait (`repositories::workspace_repository`)
+//!
+//! Definiert das Trait [`WorkspaceRepository`], das als Abstraktion für den
+//! Datenzugriff auf [`Workspace`](crate::entities::Workspace) Entitäten dient.
+//!
+//! Diese Schnittstelle muss von einer konkreten Implementierung in der Systemschicht
+//! (`novade-system`) erfüllt werden, um die Persistenz von Workspace-Daten
+//! zu gewährleisten (z.B. Speichern in einer Konfigurationsdatei oder Datenbank).
+
+use crate::entities::workspace::Workspace;
+use crate::DomainResult; // Stellt sicher, dass Fehler als DomainError zurückgegeben werden
+use async_trait::async_trait;
+use novade_core::types::NovaId;
+
+/// Ein Trait, das Operationen zum Speichern, Abrufen und Verwalten von
+/// [`Workspace`](crate::entities::Workspace)-Entitäten abstrahiert.
+///
+/// Implementierungen dieses Traits sind für die Persistenzlogik von Workspaces zuständig.
+/// Das Trait ist `async_trait`, um asynchrone Operationen zu unterstützen.
+#[cfg_attr(test, mockall::automock)] // Hinzugefügt für Mocking in Tests
+/// `Send + Sync` Bounds sind für die thread-sichere Nutzung erforderlich.
+#[async_trait]
+pub trait WorkspaceRepository: Send + Sync {
+    /// Ruft einen spezifischen Workspace anhand seiner eindeutigen ID ab.
+    ///
+    /// # Parameter
+    /// * `id`: Die [`NovaId`] des gesuchten Workspaces.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult`, das bei Erfolg `Some(Workspace)` enthält, wenn der Workspace
+    /// gefunden wurde, oder `None`, andernfalls ein `DomainError`.
+    async fn get_by_id(&self, id: &NovaId) -> DomainResult<Option<Workspace>>;
+
+    /// Ruft einen spezifischen Workspace anhand seines Namens ab.
+    ///
+    /// Da Workspace-Namen potenziell eindeutig sein sollten (innerhalb eines Benutzerkontexts),
+    /// ermöglicht diese Methode das Abrufen über den Namen.
+    ///
+    /// # Parameter
+    /// * `name`: Der Name des gesuchten Workspaces.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult`, das bei Erfolg `Some(Workspace)` enthält, wenn ein Workspace
+    /// mit diesem Namen gefunden wurde, oder `None`, andernfalls ein `DomainError`.
+    async fn get_by_name(&self, name: &str) -> DomainResult<Option<Workspace>>;
+    
+    /// Ruft eine Liste aller im System bekannten Workspaces ab.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult`, das bei Erfolg einen Vektor von `Workspace`-Entitäten enthält.
+    /// Der Vektor kann leer sein. Im Fehlerfall wird ein `DomainError` zurückgegeben.
+    async fn get_all(&self) -> DomainResult<Vec<Workspace>>;
+
+    /// Fügt einen neuen Workspace zum Repository hinzu.
+    ///
+    /// # Parameter
+    /// * `workspace`: Eine Referenz auf den hinzuzufügenden `Workspace`.
+    ///                Es wird erwartet, dass die `id` des Workspaces bereits gesetzt ist.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn ein Workspace
+    /// mit derselben ID oder demselben Namen bereits existiert).
+    async fn add(&self, workspace: &Workspace) -> DomainResult<()>;
+
+    /// Aktualisiert einen bereits im Repository vorhandenen Workspace.
+    ///
+    /// Der zu aktualisierende Workspace wird typischerweise anhand seiner `id` identifiziert.
+    ///
+    /// # Parameter
+    /// * `workspace`: Eine Referenz auf den `Workspace` mit den aktualisierten Daten.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn der Workspace
+    /// nicht gefunden wird).
+    async fn update(&self, workspace: &Workspace) -> DomainResult<()>;
+
+    /// Entfernt einen Workspace anhand seiner eindeutigen ID aus dem Repository.
+    ///
+    /// # Parameter
+    /// * `id`: Die [`NovaId`] des zu entfernenden Workspaces.
+    ///
+    /// # Rückgabe
+    /// Ein `DomainResult<()>` das bei Erfolg `Ok(())` zurückgibt.
+    /// Im Fehlerfall wird ein `DomainError` zurückgegeben (z.B. wenn kein Workspace
+    /// mit dieser ID gefunden wird).
+    async fn remove(&self, id: &NovaId) -> DomainResult<()>;
+}

--- a/novade-domain/src/services/application_service.rs
+++ b/novade-domain/src/services/application_service.rs
@@ -1,0 +1,135 @@
+//! Domänendienst für die Verwaltung von Anwendungen.
+
+use crate::entities::application::{Application, ApplicationType};
+use crate::repositories::application_repository::ApplicationRepository;
+use crate::{DomainError, DomainResult};
+use novade_core::types::NovaId;
+use novade_core::info; // Logging
+use std::sync::Arc;
+
+pub struct ApplicationService {
+    app_repository: Arc<dyn ApplicationRepository>,
+}
+
+impl ApplicationService {
+    /// Erstellt einen neuen `ApplicationService`.
+    pub fn new(app_repository: Arc<dyn ApplicationRepository>) -> Self {
+        Self { app_repository }
+    }
+
+    /// Listet alle bekannten Anwendungen auf.
+    pub async fn list_all_applications(&self) -> DomainResult<Vec<Application>> {
+        info!("Auflistung aller Anwendungen angefordert.");
+        self.app_repository.get_all().await
+    }
+
+    /// Sucht Anwendungen anhand eines Namens.
+    pub async fn find_applications_by_name(&self, name_query: &str) -> DomainResult<Vec<Application>> {
+        if name_query.trim().is_empty() {
+            return Err(DomainError::ValidationError {
+                field: "name_query".to_string(),
+                message: "Suchbegriff darf nicht leer sein.".to_string(),
+            });
+        }
+        info!(name_query, "Suche nach Anwendungen.");
+        self.app_repository.find_by_name(name_query).await
+    }
+    
+    /// Registriert eine neue Anwendung im System.
+    pub async fn register_application(&self, app_data: Application) -> DomainResult<Application> {
+        info!(app_name = %app_data.name, app_id = %app_data.id, "Registriere neue Anwendung.");
+        // Hier könnten Validierungen stattfinden, z.B. ob der Pfad existiert (obwohl das eher Systemschicht wäre)
+        // oder ob eine Anwendung mit gleichem Namen/Pfad schon existiert.
+        if app_data.executable_path.trim().is_empty() {
+             return Err(DomainError::ValidationError {
+                field: "executable_path".to_string(),
+                message: "Pfad zur ausführbaren Datei darf nicht leer sein.".to_string(),
+            });
+        }
+        self.app_repository.add(&app_data).await?;
+        Ok(app_data)
+    }
+
+    /// Ruft Details zu einer spezifischen Anwendung ab.
+    pub async fn get_application_details(&self, app_id: &NovaId) -> DomainResult<Option<Application>> {
+        info!(%app_id, "Details für Anwendung angefordert.");
+        self.app_repository.get_by_id(app_id).await
+    }
+
+    // Weitere Methoden, z.B. für das Starten einer Anwendung (was hier eher das
+    // "Vorbereiten zum Starten" bedeuten würde, der eigentliche Prozessstart
+    // wäre in der Systemschicht).
+    // pub async fn prepare_launch_application(&self, app_id: &NovaId) -> DomainResult<LaunchInfo> { ... }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repositories::application_repository::MockApplicationRepository; // mockall generiert dies
+    use novade_core::CoreError; // für RepositoryError wrapping
+    use tokio; // für async tests
+
+    #[tokio::test]
+    async fn test_list_all_applications_success() {
+        let mut mock_repo = MockApplicationRepository::new();
+        let app1 = Application::new_desktop("App1".to_string(), "/bin/app1".to_string(), None);
+        let app2 = Application::new_desktop("App2".to_string(), "/bin/app2".to_string(), None);
+        let expected_apps = vec![app1.clone(), app2.clone()];
+
+        mock_repo
+            .expect_get_all()
+            .times(1)
+            .returning(move || Ok(expected_apps.clone()));
+
+        let service = ApplicationService::new(Arc::new(mock_repo));
+        let result = service.list_all_applications().await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_applications_error() {
+        let mut mock_repo = MockApplicationRepository::new();
+        let core_err = CoreError::UnknownError("Datenbank nicht erreichbar".to_string());
+        
+        mock_repo
+            .expect_get_all()
+            .times(1)
+            .returning(move || Err(DomainError::RepositoryError(core_err.clone())));
+
+        let service = ApplicationService::new(Arc::new(mock_repo));
+        let result = service.list_all_applications().await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DomainError::RepositoryError(CoreError::UnknownError(msg)) => {
+                assert_eq!(msg, "Datenbank nicht erreichbar");
+            }
+            _ => panic!("Falscher Fehlertyp"),
+        }
+    }
+    
+    #[tokio::test]
+    async fn test_register_application_empty_path() {
+        let mock_repo = MockApplicationRepository::new(); // Wird nicht aufgerufen
+        let service = ApplicationService::new(Arc::new(mock_repo));
+        let app_data = Application {
+            id: NovaId::new(),
+            name: "Test App".to_string(),
+            display_name: None,
+            executable_path: " ".to_string(), // Leerer Pfad
+            arguments: None,
+            working_directory: None,
+            icon_name: None,
+            app_type: ApplicationType::Desktop,
+            categories: None,
+            keywords: None,
+            description: None,
+            version: None,
+        };
+
+        let result = service.register_application(app_data).await;
+        assert!(matches!(result, Err(DomainError::ValidationError {field, ..}) if field == "executable_path"));
+    }
+}

--- a/novade-domain/src/services/mod.rs
+++ b/novade-domain/src/services/mod.rs
@@ -1,0 +1,12 @@
+//! Das `services` Modul enthält die Domänendienste, welche die Geschäftslogik
+//! der NovaDE-Domäne implementieren. Sie verwenden Repository-Traits für den
+//! Datenzugriff und operieren auf Domänenentitäten.
+
+pub mod application_service;
+pub mod workspace_service;
+// Zukünftig: user_preference_service.rs
+
+// Re-exportiere die Dienste für einfacheren Zugriff.
+pub use application_service::ApplicationService;
+pub use workspace_service::WorkspaceService;
+// pub use user_preference_service::UserPreferenceService;

--- a/novade-domain/src/services/workspace_service.rs
+++ b/novade-domain/src/services/workspace_service.rs
@@ -1,0 +1,105 @@
+//! Domänendienst für die Verwaltung von Workspaces.
+
+use crate::entities::workspace::Workspace;
+use crate::repositories::workspace_repository::WorkspaceRepository;
+use crate::{DomainError, DomainResult};
+use novade_core::types::NovaId;
+use novade_core::info; // Logging
+use std::sync::Arc;
+
+pub struct WorkspaceService {
+    workspace_repository: Arc<dyn WorkspaceRepository>,
+}
+
+impl WorkspaceService {
+    pub fn new(workspace_repository: Arc<dyn WorkspaceRepository>) -> Self {
+        Self { workspace_repository }
+    }
+
+    pub async fn create_new_workspace(&self, name: String, primary_output_id: Option<String>) -> DomainResult<Workspace> {
+        if name.trim().is_empty() {
+            return Err(DomainError::ValidationError {
+                field: "name".to_string(),
+                message: "Workspace-Name darf nicht leer sein.".to_string(),
+            });
+        }
+        // Prüfen, ob ein Workspace mit diesem Namen bereits existiert
+        if self.workspace_repository.get_by_name(&name).await?.is_some() {
+            return Err(DomainError::OperationNotPermitted {
+                operation: "create_workspace".to_string(),
+                reason: format!("Ein Workspace mit dem Namen '{}' existiert bereits.", name),
+            });
+        }
+
+        let workspace = Workspace::new(name.clone(), primary_output_id);
+        info!(workspace_id = %workspace.id, workspace_name = %workspace.name, "Erstelle neuen Workspace.");
+        self.workspace_repository.add(&workspace).await?;
+        Ok(workspace)
+    }
+
+    pub async fn list_all_workspaces(&self) -> DomainResult<Vec<Workspace>> {
+        info!("Auflistung aller Workspaces angefordert.");
+        self.workspace_repository.get_all().await
+    }
+    
+    pub async fn get_workspace_details(&self, id: &NovaId) -> DomainResult<Option<Workspace>> {
+        info!(workspace_id = %id, "Details für Workspace angefordert.");
+        self.workspace_repository.get_by_id(id).await
+    }
+
+    // Weitere Methoden z.B. zum Wechseln, Schließen, Umbenennen von Workspaces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repositories::workspace_repository::MockWorkspaceRepository;
+    use tokio;
+
+    #[tokio::test]
+    async fn test_create_new_workspace_success() {
+        let mut mock_repo = MockWorkspaceRepository::new();
+        let workspace_name = "Test Workspace".to_string();
+
+        mock_repo.expect_get_by_name()
+            .withf(move |name_param: &str| name_param == workspace_name)
+            .times(1)
+            .returning(|_| Ok(None)); // Kein Workspace mit dem Namen existiert
+
+        mock_repo.expect_add()
+            .times(1)
+            .returning(|_ws| Ok(()));
+        
+        let service = WorkspaceService::new(Arc::new(mock_repo));
+        let result = service.create_new_workspace("Test Workspace".to_string(), None).await;
+
+        assert!(result.is_ok());
+        let workspace = result.unwrap();
+        assert_eq!(workspace.name, "Test Workspace");
+    }
+
+    #[tokio::test]
+    async fn test_create_new_workspace_name_exists() {
+        let mut mock_repo = MockWorkspaceRepository::new();
+        let existing_workspace = Workspace::new("Existing".to_string(), None);
+        
+        mock_repo.expect_get_by_name()
+            .withf(|name: &str| name == "Existing")
+            .times(1)
+            .returning(move |_| Ok(Some(existing_workspace.clone())));
+
+        // add wird nicht erwartet
+        mock_repo.expect_add().never();
+
+        let service = WorkspaceService::new(Arc::new(mock_repo));
+        let result = service.create_new_workspace("Existing".to_string(), None).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DomainError::OperationNotPermitted { reason, .. } => {
+                assert!(reason.contains("existiert bereits"));
+            }
+            _ => panic!("Falscher Fehlertyp"),
+        }
+    }
+}


### PR DESCRIPTION
I've implemented the domain layer (novade-domain) of the NovaDE project. This layer contains the core logic and domain-specific entities and builds upon novade-core.

Key contents:
- `error.rs`: Domain-specific error enum (`DomainError`) and `DomainResult<T>`.
- `entities/`: Definitions for `Application`, `ApplicationType`, `Workspace`, `UserPreferenceSetting`, and `PreferenceValue`. All entities are equipped with `serde`.
- `repositories/`: Traits (`ApplicationRepository`, `WorkspaceRepository`, `UserPreferenceRepository`) with `async-trait` for data access abstraction. These define the interfaces for the system layer.
- `services/`: Domain services (`ApplicationService`, `WorkspaceService`) that implement business logic using the repository traits. Includes unit tests with `mockall` for the repositories.
- Documentation: All public APIs in `lib.rs` and the modules are documented with Rustdoc comments.
- Tests: Unit tests for services and other logic, which pass successfully.

Adjustments in `novade-core`:
- `CoreError` was made `Clone`-able by replacing `std::io::Error` in some variants with `String` representations to enable mocking in `novade-domain`.

Formatting (`cargo fmt`) and extended linting (`cargo clippy`) could not be fully performed due to environmental constraints, however, manually identified compiler errors and warnings have been addressed.