### PR TITLE
feat: Add initial GitHub Actions CI workflow for Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,65 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal # Optional: Install a minimal toolchain
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4 # Updated to v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build workspace
+        run: cargo build --workspace --exclude novade-system --exclude novade-ui
+        env:
+          CARGO_TERM_COLOR: always
+
+      - name: Run tests
+        run: cargo test --workspace --exclude novade-system --exclude novade-ui
+        env:
+          CARGO_TERM_COLOR: always
+
+  lint:
+    name: Lint (Clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --exclude novade-system --exclude novade-ui -- -D warnings
+        env:
+          CARGO_TERM_COLOR: always


### PR DESCRIPTION
This commit introduces a basic CI pipeline for your NovaDE Rust workspace.

The workflow includes two parallel jobs:
1.  `build_and_test`:
    *   Checks out the code.
    *   Installs the stable Rust toolchain.
    *   Caches Cargo dependencies to speed up builds.
    *   Builds the workspace using `cargo build --workspace`.
    *   Runs tests using `cargo test --workspace`.
    *   Currently, `novade-system` and `novade-ui` crates are excluded from build and test due to their incomplete state (commented-out dependencies). This is a temporary measure to allow the CI to pass.

2.  `lint`:
    *   Checks out the code.
    *   Installs the stable Rust toolchain with the Clippy component.
    *   Runs `cargo clippy --workspace -- -D warnings` to perform static analysis and enforce code style.
    *   Also excludes `novade-system` and `novade-ui` from linting for now.

This initial setup provides a foundation for automated checks on push and pull requests to the main branch. Future enhancements can include matrix builds, release automation, and code coverage.