### PR TITLE
feat: Implement clipboard management module

### DIFF
--- a/novade-system/src/client.rs
+++ b/novade-system/src/client.rs
@@ -34,6 +34,19 @@ pub enum ClientRequest {
     // CloseWindow { client_id: u32, window_id: u32 },
     // MapWindow { client_id: u32, window_id: u32 },
     // UnmapWindow { client_id: u32, window_id: u32 },
+
+    /// Request to copy text to the clipboard.
+    CopyText {
+        /// The ID of the client making the request.
+        client_id: u32,
+        /// The text to copy.
+        text: String,
+    },
+    /// Request to paste text from the clipboard.
+    PasteTextRequest {
+        /// The ID of the client making the request.
+        client_id: u32,
+    },
 }
 
 /// Represents events that the server can send to clients (or use internally for now).
@@ -52,4 +65,17 @@ pub enum ServerEvent {
     // WindowClosed { window_id: u32 },
     // WindowMapped { window_id: u32 },
     // WindowUnmapped { window_id: u32 },
+
+    /// Indicates that text was successfully copied by a client.
+    TextCopied {
+        /// The ID of the client that copied the text.
+        client_id: u32,
+    },
+    /// Response to a paste request, containing the clipboard text.
+    PasteTextResponse {
+        /// The ID of the client that requested the paste.
+        client_id: u32,
+        /// The text from the clipboard, or None if empty.
+        text: Option<String>,
+    },
 }

--- a/novade-system/src/clipboard/mod.rs
+++ b/novade-system/src/clipboard/mod.rs
@@ -1,0 +1,75 @@
+// novade-system/src/clipboard/mod.rs
+
+#[derive(Debug, Default)]
+pub struct Clipboard {
+    data: Option<String>,
+}
+
+impl Clipboard {
+    /// Creates a new Clipboard instance.
+    pub fn new() -> Self {
+        Clipboard { data: None }
+    }
+
+    /// Sets the clipboard data.
+    pub fn set_data(&mut self, data: String) {
+        self.data = Some(data);
+    }
+
+    /// Retrieves the clipboard data.
+    pub fn get_data(&self) -> Option<String> {
+        self.data.clone()
+    }
+
+    /// Clears the clipboard data.
+    pub fn clear_data(&mut self) {
+        self.data = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clipboard_new() {
+        let clipboard = Clipboard::new();
+        assert_eq!(clipboard.get_data(), None);
+    }
+
+    #[test]
+    fn test_clipboard_set_get_data() {
+        let mut clipboard = Clipboard::new();
+        let test_data = "Hello, clipboard!".to_string();
+
+        // Set data
+        clipboard.set_data(test_data.clone());
+        assert_eq!(clipboard.get_data(), Some(test_data.clone()));
+
+        // Get data
+        let retrieved_data = clipboard.get_data();
+        assert_eq!(retrieved_data, Some(test_data));
+
+        // Clear data and check
+        clipboard.clear_data();
+        assert_eq!(clipboard.get_data(), None);
+    }
+
+    #[test]
+    fn test_clipboard_clear_data() {
+        let mut clipboard = Clipboard::new();
+        let test_data = "Some data".to_string();
+
+        // Set some data first
+        clipboard.set_data(test_data.clone());
+        assert_eq!(clipboard.get_data(), Some(test_data));
+
+        // Clear data
+        clipboard.clear_data();
+        assert_eq!(clipboard.get_data(), None);
+
+        // Clear again when already empty
+        clipboard.clear_data();
+        assert_eq!(clipboard.get_data(), None);
+    }
+}

--- a/novade-system/src/input/event.rs
+++ b/novade-system/src/input/event.rs
@@ -100,4 +100,9 @@ pub enum InputEvent {
         /// The state of modifier keys at the time of the event.
         modifiers: Modifiers,
     },
+    // Clipboard shortcuts, processed by the server.
+    /// Ctrl+C was pressed.
+    CopyShortcut,
+    /// Ctrl+V was pressed.
+    PasteShortcut,
 }

--- a/novade-system/src/input/manager.rs
+++ b/novade-system/src/input/manager.rs
@@ -1,7 +1,12 @@
 // src/input/manager.rs
 
 use crate::input::state::InputState;
-use crate::input::event::InputEvent; // Added import
+use crate::input::event::{InputEvent, KeyState, Modifiers}; // Added KeyState and Modifiers
+
+// Define assumed key codes for C and V.
+// These are based on ASCII, but in a real system might come from xkbcommon or similar.
+const KEY_C: u32 = 67;
+const KEY_V: u32 = 86;
 
 /// Manages the overall input state and processes incoming events.
 #[derive(Debug, Default)]
@@ -35,6 +40,19 @@ impl InputManager {
     /// process the event.
     pub fn process_simulated_raw_event(&mut self, event: InputEvent) -> InputEvent {
         self.input_state.update_from_event(&event);
+
+        // Check for clipboard shortcuts
+        if let InputEvent::Keyboard { key_code, state, modifiers } = event {
+            if modifiers.ctrl && state == KeyState::Pressed {
+                if key_code == KEY_C {
+                    println!("InputManager: Detected Ctrl+C shortcut.");
+                    return InputEvent::CopyShortcut;
+                } else if key_code == KEY_V {
+                    println!("InputManager: Detected Ctrl+V shortcut.");
+                    return InputEvent::PasteShortcut;
+                }
+            }
+        }
         event
     }
 }

--- a/novade-system/src/lib.rs
+++ b/novade-system/src/lib.rs
@@ -1,12 +1,14 @@
 // src/lib.rs
 
 pub mod client; // Added client module
+pub mod clipboard;
 pub mod compositor;
 pub mod input;
 pub mod server;
 
 // Re-export key types
 pub use client::{Client, ClientRequest, ServerEvent}; // Added re-exports
+pub use clipboard::Clipboard;
 pub use server::Server;
 
 #[cfg(test)]

--- a/novade-system/src/server.rs
+++ b/novade-system/src/server.rs
@@ -1,5 +1,6 @@
 // src/server.rs
 
+use crate::clipboard::Clipboard;
 use crate::compositor::core::{CompositorState, Window}; // Window needs to be in scope
 use crate::input::{InputManager, InputEvent};
 use crate::client::{Client, ClientRequest, ServerEvent}; // ClientRequest, ServerEvent needed
@@ -15,6 +16,8 @@ pub struct Server {
     pub clients: Vec<Client>,
     /// Counter for generating unique client IDs.
     next_client_id: u32,
+    /// The server's clipboard instance.
+    pub clipboard: Clipboard,
 }
 
 impl Server {
@@ -25,6 +28,7 @@ impl Server {
             input_manager: InputManager::new(),
             clients: Vec::new(),
             next_client_id: 1,
+            clipboard: Clipboard::new(),
         }
     }
 
@@ -92,6 +96,22 @@ impl Server {
                     initial_geometry: geometry,
                 })
             }
+            ClientRequest::CopyText { client_id, text } => {
+                if !self.clients.iter().any(|c| c.id == client_id) {
+                    eprintln!("Server Error: CopyText request from non-existent client ID: {}", client_id);
+                    return None;
+                }
+                self.set_clipboard_data(text);
+                Some(ServerEvent::TextCopied { client_id })
+            }
+            ClientRequest::PasteTextRequest { client_id } => {
+                if !self.clients.iter().any(|c| c.id == client_id) {
+                    eprintln!("Server Error: PasteTextRequest from non-existent client ID: {}", client_id);
+                    return None;
+                }
+                let text = self.get_clipboard_data();
+                Some(ServerEvent::PasteTextResponse { client_id, text })
+            }
             // Handle other ClientRequest variants here in the future
             // _ => {
             //     println!("Server: Received unhandled client request type.");
@@ -113,14 +133,39 @@ impl Server {
 
         // 1. Process all incoming simulated events
         for event in simulated_events {
-            println!("Server: Processing event: {:?}", event);
+            println!("Server: Processing raw event: {:?}", event);
             let processed_event = self.input_manager.process_simulated_raw_event(event);
-            println!("Server: Dispatching processed event: {:?}", processed_event);
-            let dispatched = self.compositor_state.dispatch_input_event(&processed_event, "seat0");
-            if dispatched {
-                println!("Server: Event dispatched successfully to focused window on seat0.");
-            } else {
-                println!("Server: Event dispatch failed or no window focused on seat0.");
+
+            match processed_event {
+                InputEvent::CopyShortcut => {
+                    // In a real scenario, we'd try to get data from the "focused" window.
+                    // For now, we simulate this with a predefined string.
+                    let data_to_copy = "Simulated copied text from active window".to_string();
+                    self.set_clipboard_data(data_to_copy);
+                    println!("Server: Detected CopyShortcut, data set to clipboard.");
+                    // This event is handled by the server, not dispatched to windows.
+                }
+                InputEvent::PasteShortcut => {
+                    let clipboard_content = self.get_clipboard_data();
+                    if let Some(data) = clipboard_content {
+                        println!("Server: Detected PasteShortcut, data: '{}' would be sent to active window.", data);
+                        // In a real scenario, this data would be sent to the focused window.
+                        // For now, we just print it.
+                    } else {
+                        println!("Server: Detected PasteShortcut, no data in clipboard.");
+                    }
+                    // This event is handled by the server, not dispatched to windows.
+                }
+                _ => {
+                    // If it's not a server-handled shortcut, dispatch it to the compositor
+                    println!("Server: Dispatching processed event to compositor: {:?}", processed_event);
+                    let dispatched = self.compositor_state.dispatch_input_event(&processed_event, "seat0");
+                    if dispatched {
+                        println!("Server: Event dispatched successfully to focused window on seat0.");
+                    } else {
+                        println!("Server: Event dispatch failed or no window focused on seat0 for event: {:?}", processed_event);
+                    }
+                }
             }
         }
 
@@ -132,6 +177,154 @@ impl Server {
         }
         println!("Server: Loop iteration finished.");
     }
+
+    /// Sets the server's clipboard data.
+    pub fn set_clipboard_data(&mut self, data: String) {
+        self.clipboard.set_data(data);
+        println!("Server: Clipboard data set.");
+    }
+
+    /// Retrieves the server's clipboard data.
+    pub fn get_clipboard_data(&self) -> Option<String> {
+        let data = self.clipboard.get_data();
+        println!("Server: Clipboard data retrieved.");
+        data
+    }
+
+    /// Clears the server's clipboard data.
+    pub fn clear_clipboard_data(&mut self) {
+        self.clipboard.clear_data();
+        println!("Server: Clipboard data cleared.");
+    }
 }
 
 impl Default for Server { fn default() -> Self { Self::new() } } // Ensure this is present
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::{ClientRequest, ServerEvent};
+    use crate::input::event::{InputEvent, KeyState, Modifiers};
+
+    // Redefine key codes for testing purposes if not accessible
+    const KEY_C: u32 = 67;
+    const KEY_V: u32 = 86;
+
+    fn create_server_with_client() -> (Server, u32) {
+        let mut server = Server::new();
+        let client_id = server.add_client();
+        (server, client_id)
+    }
+
+    #[test]
+    fn test_server_handle_copy_text_request() {
+        let (mut server, client_id) = create_server_with_client();
+        let text_to_copy = "Hello from client".to_string();
+
+        let request = ClientRequest::CopyText {
+            client_id,
+            text: text_to_copy.clone(),
+        };
+        let response = server.process_client_request(request);
+
+        assert_eq!(response, Some(ServerEvent::TextCopied { client_id }));
+        assert_eq!(server.get_clipboard_data(), Some(text_to_copy));
+    }
+
+    #[test]
+    fn test_server_handle_paste_text_request() {
+        let (mut server, client_id) = create_server_with_client();
+        let clipboard_content = "Existing clipboard data".to_string();
+        server.set_clipboard_data(clipboard_content.clone());
+
+        let request = ClientRequest::PasteTextRequest { client_id };
+        let response = server.process_client_request(request);
+
+        assert_eq!(
+            response,
+            Some(ServerEvent::PasteTextResponse {
+                client_id,
+                text: Some(clipboard_content)
+            })
+        );
+    }
+
+    #[test]
+    fn test_server_handle_paste_text_request_empty_clipboard() {
+        let (mut server, client_id) = create_server_with_client();
+        server.clear_clipboard_data(); // Ensure clipboard is empty
+
+        let request = ClientRequest::PasteTextRequest { client_id };
+        let response = server.process_client_request(request);
+
+        assert_eq!(
+            response,
+            Some(ServerEvent::PasteTextResponse {
+                client_id,
+                text: None
+            })
+        );
+    }
+
+    #[test]
+    fn test_server_handle_clipboard_request_invalid_client() {
+        let mut server = Server::new();
+        let invalid_client_id = 999; // A client ID that has not been added
+
+        // Test CopyText with invalid client
+        let copy_request = ClientRequest::CopyText {
+            client_id: invalid_client_id,
+            text: "test".to_string(),
+        };
+        let copy_response = server.process_client_request(copy_request);
+        assert_eq!(copy_response, None);
+
+        // Test PasteTextRequest with invalid client
+        let paste_request = ClientRequest::PasteTextRequest {
+            client_id: invalid_client_id,
+        };
+        let paste_response = server.process_client_request(paste_request);
+        assert_eq!(paste_response, None);
+    }
+
+    #[test]
+    fn test_server_handle_copy_shortcut() {
+        let mut server = Server::new();
+        let ctrl_c_event = InputEvent::Keyboard {
+            key_code: KEY_C,
+            state: KeyState::Pressed,
+            modifiers: Modifiers { ctrl: true, shift: false, alt: false, logo: false },
+        };
+
+        server.run_loop_iteration(vec![ctrl_c_event]);
+
+        assert_eq!(
+            server.get_clipboard_data(),
+            Some("Simulated copied text from active window".to_string())
+        );
+    }
+
+    #[test]
+    fn test_server_handle_paste_shortcut() {
+        let mut server = Server::new();
+        let initial_clipboard_data = "Test paste data".to_string();
+        server.set_clipboard_data(initial_clipboard_data.clone());
+
+        let ctrl_v_event = InputEvent::Keyboard {
+            key_code: KEY_V,
+            state: KeyState::Pressed,
+            modifiers: Modifiers { ctrl: true, shift: false, alt: false, logo: false },
+        };
+
+        // Note: This test primarily checks that the clipboard state remains unchanged
+        // and that the server processes the event (indicated by println! in implementation).
+        // A more robust test would capture stdout or use a more testable event handling mechanism.
+        server.run_loop_iteration(vec![ctrl_v_event]);
+
+        // Paste operation should not clear the clipboard
+        assert_eq!(server.get_clipboard_data(), Some(initial_clipboard_data));
+        
+        // Further checks could involve capturing stdout if the test environment supports it
+        // and looking for "Server: Detected PasteShortcut, data: 'Test paste data'..."
+    }
+}


### PR DESCRIPTION
This commit introduces a new clipboard management module to NovaDE.

The module includes:
- A `Clipboard` struct for storing and managing clipboard data (text-based for now).
- Integration with the `Server` to handle clipboard operations via client requests (`CopyText`, `PasteTextRequest`) and corresponding server events.
- Integration with the `InputManager` to detect and handle Ctrl+C and Ctrl+V keyboard shortcuts.
  - Ctrl+C currently sets a predefined text to the clipboard.
  - Ctrl+V currently retrieves text from the clipboard (intended for future pasting into focused applications).

Unit tests have been added to cover:
- Basic clipboard operations (set, get, clear).
- Server handling of clipboard-related client requests.
- Server handling of copy and paste keyboard shortcuts.